### PR TITLE
Fix out of bound dialogue windows

### DIFF
--- a/aas_editor/dialogs.py
+++ b/aas_editor/dialogs.py
@@ -105,7 +105,7 @@ class ErrorMessageBox(QMessageBox):
 class AddDialog(QDialog):
     """Base abstract class for custom dialogs for adding data"""
     REC = QGuiApplication.primaryScreen().geometry()
-    MAX_HEIGHT = int(REC.height() * 0.9)
+    MAX_HEIGHT = int(REC.height() * 0.6)
     MIN_WIDTH = 450
     INITIAL_POSITION = None
 


### PR DESCRIPTION
Fixes https://github.com/rwth-iat/aas_manager/issues/22

From the start position of the new window, the new limit will prevent the window from going outside the screen boundaries.