### PR TITLE
Implement test script

### DIFF
--- a/test.py
+++ b/test.py
@@ -18,6 +18,7 @@ from PyQt6 import QtWebEngineWidgets
 from PyQt6.QtCore import Qt
 from PyQt6.QtTest import QTest
 
+                        
 from basyx.aas.model import AssetAdministrationShell, ConceptDescription, Submodel, Property, \
     Entity, Capability, Operation, RelationshipElement, AnnotatedRelationshipElement, Range, Blob, File, \
     ReferenceElement, DataElement, AdministrativeInformation, AbstractObjectStore, \
@@ -52,6 +53,7 @@ def main():
     
     prev_time = time.time()
     while True:
+        from aas_editor import dialogs
         app.processEvents()
         current_time = time.time()
         if int(current_time) != int(prev_time):
@@ -67,7 +69,7 @@ def main():
             model = tree.model()
             root = model.index(0, 0)
             
-            if (int(current_time) - int(prev_time)) > 10:
+            if (int(current_time) - int(prev_time)) > 100:
                 break
             
             elif root.isValid():
@@ -81,9 +83,13 @@ def main():
                         tree.setCurrentIndex(item_index)
                         app.processEvents()
                         time.sleep(1)
-                        from aas_editor import dialogs
                         dialog = dialogs.AddObjDialog(Submodel, parent=tree, objVal=None, title='', rmDefParams=False)
                         dialog.show()
+                        
+                        time.sleep(1)
+                        app.processEvents()
+                        time.sleep(1)
+                        
                         app.processEvents()
                         dialog.accept()
                         obj = tree._getObjFromDialog(dialog)
@@ -95,6 +101,57 @@ def main():
                         time.sleep(1)
                         
                         tree.onDelClear()
+                        
+                        time.sleep(1)
+                        app.processEvents()
+                        time.sleep(1)
+                        
+                    elif item_data == 'shells':
+                        tree.setCurrentIndex(item_index)
+                        app.processEvents()
+                        dialog = dialogs.AddObjDialog(AssetAdministrationShell, parent=tree, objVal=None, title='', rmDefParams=False)
+                        dialog.show()
+                        
+                        time.sleep(1)
+                        app.processEvents()
+                        time.sleep(1)
+                        
+                        dialog.reject()
+                        dialog.deleteLater()
+                        
+                        time.sleep(1)
+                        app.processEvents()
+                        time.sleep(1)
+                       
+                    elif item_data == 'fileStore':
+                        tree.setCurrentIndex(item_index)
+                        app.processEvents()
+                        dialog = dialogs.AddObjDialog(File, parent=tree, objVal=None, title='', rmDefParams=False)
+                        dialog.show()
+
+                        time.sleep(1)
+                        app.processEvents()
+                        time.sleep(1)
+                        
+                        dialog.reject()
+                        dialog.deleteLater()
+                        
+                        time.sleep(1)
+                        app.processEvents()
+                        time.sleep(1)
+                        
+                    elif item_data == 'concept_descriptions':
+                        tree.setCurrentIndex(item_index)
+                        app.processEvents()
+                        dialog = dialogs.AddObjDialog(ConceptDescription, parent=tree, objVal=None, title='', rmDefParams=False)
+                        dialog.show()
+
+                        time.sleep(1)
+                        app.processEvents()
+                        time.sleep(1)
+                        
+                        dialog.reject()
+                        dialog.deleteLater()
                         
                         time.sleep(1)
                         app.processEvents()


### PR DESCRIPTION
Solves https://github.com/rwth-iat/aas_manager/issues/27.

First three points are solved in completion. For it to work, the script test.py should be called like one normally would. ```python3 test.py /path/to/test.aasx```. A custom test.aasx has to be pushed also as the subject. It can have any format, it does not need to be hardcoded or anything.

Potential solution for the last part is also added but commented out, because there is no direct way of closing the dialog window properly. I have implemented a time out mechanism here. Which is a nice workaround, but it is a sub-optimal solution at best.

More intricate ways are possible, still in code, but this would come with more disadvantages than what it would provide. A not so much complicated solution would be maybe using [pytest-qt](https://pypi.org/project/pytest-qt/). This would mean that we can just emulate user keyboard strokes and mouse clicks. This would actually be very good solution, but it would force some hardcoding of sorts. We can change our ways to this if it would be desired.