### PR TITLE
.github/workflows: Update Artifact Actions

### DIFF
--- a/.github/workflows/manual_build.yaml
+++ b/.github/workflows/manual_build.yaml
@@ -28,7 +28,7 @@ jobs:
         cd dist
         7z a AAS_Manager_Win.zip AAS_Manager
     - name: Save Build in artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: AAS_Manager_Win
         path: ./dist/AAS_Manager_Win.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
         run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
 
       - name: Save Release URL File for publish
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: release_url
           path: release_url.txt
@@ -117,7 +117,7 @@ jobs:
       - name: Build with pyinstaller for ${{matrix.TARGET}}
         run: ${{matrix.CMD_BUILD}}
       - name: Load Release URL File from release job
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: release_url
       - name: Get Release File Name & Upload URL


### PR DESCRIPTION
Currently, we're running the GitHub Artifact Actions v3 or lower, which will be deprecated by
2025-01-31, as noticed in [this blog post](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

This updates the actions to version 4 in order to avoid workflow failure.
