### PR TITLE
Feature/copy idshortpath

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v3
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ You can find binaries of the editor for Windows or Linux systems in [the release
    ```
 2. Install requirements
    ```sh
-   pip install -e .
+   pip install .
    ```
-   Note: If errors occur, try installing the packages one by one in the same order linke in requirements.txt 
+   Note: If errors occur, try installing the packages one by one in the same order like in dependencies in `pyproject.toml` file.
   
    **Linux Dependencies:**
    On some Linux distributions, you may encounter PyQt5-related errors when running the application. If this happens, you'll need to install missing system dependencies. See issue [#38](https://github.com/rwth-iat/aas_manager/issues/38) for detailed instructions and solutions.
 
-3. Run ``aas_editor``
+3. Run ``main.py`` file
 
 OR
 

--- a/aas_editor/dialogs.py
+++ b/aas_editor/dialogs.py
@@ -25,7 +25,7 @@ from PyQt6.QtWidgets import QPushButton, QDialog, QDialogButtonBox, \
 from aas_editor.editWidgets import StandardInputWidget
 from aas_editor.settings import DEFAULTS, DEFAULT_COMPLETIONS, ATTRIBUTE_COLUMN, OBJECT_ROLE, \
     DEFAULT_INHERITOR, AAS_METAMODEL_VERSION
-from settings import VERSION, APPLICATION_NAME, APPLICATION_INFO, COPYRIGHT_YEAR, CONTRIBUTORS, DEVELOPER_WEB, CONTACT, \
+from aas_editor.settings import VERSION, APPLICATION_NAME, APPLICATION_INFO, COPYRIGHT_YEAR, CONTRIBUTORS, DEVELOPER_WEB, CONTACT, \
     REPORT_ERROR_LINK, APPLICATION_LINK, LICENSE
 from aas_editor.utils.util import inheritors, getReqParams4init, getParamsAndTypehints4init, getDefaultVal, \
     actualizeAASParents, delAASParent

--- a/aas_editor/editorApp.py
+++ b/aas_editor/editorApp.py
@@ -16,15 +16,15 @@ from PyQt6.QtWidgets import *
 
 from aas_editor.settings.app_settings import *
 from aas_editor.settings.icons import EXIT_ICON, SETTINGS_ICON, NEW_PACK_ICON, initialize_all_icons
+from aas_editor.settings import APPLICATION_NAME, REPORT_ERROR_LINK
 from aas_editor.settings_dialog import SettingsDialog
-from widgets.aas_test_engines_tool import AasTestEnginesToolDialog
+from aas_editor.widgets.aas_test_engines_tool import AasTestEnginesToolDialog
 from aas_editor.widgets import AddressLine
 from aas_editor import design
 from aas_editor.models import DetailedInfoTable, PacksTable
 from aas_editor.utils.util import toggleStylesheet
 from aas_editor import dialogs
 from aas_editor.widgets.treeview import HeaderView
-from settings import APPLICATION_NAME, REPORT_ERROR_LINK
 
 
 class EditorApp(QMainWindow, design.Ui_MainWindow):

--- a/aas_editor/package.py
+++ b/aas_editor/package.py
@@ -16,8 +16,8 @@ import mimetypes
 
 import pyecma376_2
 from basyx.aas.adapter.aasx import DictSupplementaryFileContainer, AASXReader, AASXWriter
-from basyx.aas.adapter.json import read_aas_json_file, write_aas_json_file
-from basyx.aas.adapter.xml import read_aas_xml_file, write_aas_xml_file
+from basyx.aas.adapter.json import write_aas_json_file, read_aas_json_file_into
+from basyx.aas.adapter.xml import write_aas_xml_file, read_aas_xml_file_into
 from basyx.aas.model import AssetAdministrationShell, Submodel, ConceptDescription, \
     SetObjectStore, Key, ModelReference
 
@@ -72,13 +72,13 @@ class Package:
         if fileType == ".xml":
             # The file must be opened in binary mode! The XML writer will handle
             # character encoding internally.
-            with open(self.file, 'rb') as xml_file:
-                self.objStore = read_aas_xml_file(xml_file, failsafe=failsafe)
+            with open(self.file, 'rb') as f:
+                read_aas_xml_file_into(self.objStore, f, failsafe=failsafe)
         elif fileType == ".json":
             # Using 'utf-8-sig' is recommended to handle unicode Byte Order
             # Marks (BOM) correctly.
             with open(self.file, "r", encoding='utf-8-sig') as f:
-                self.objStore = read_aas_json_file(f, failsafe=failsafe)
+                read_aas_json_file_into(self.objStore, f, failsafe=failsafe)
         elif fileType == ".aasx":
             reader = AASXReader(self.file.as_posix())
             reader.read_into(self.objStore, self.fileStore, failsafe=failsafe)

--- a/aas_editor/settings/aas_settings.py
+++ b/aas_editor/settings/aas_settings.py
@@ -15,11 +15,13 @@ from enum import Enum
 from pathlib import Path
 
 import basyx.aas.model
+from basyx.aas.adapter.aasx import AbstractSupplementaryFileContainer
 from basyx.aas.model import AssetAdministrationShell, ConceptDescription, Submodel, Property, \
     Entity, Capability, Operation, RelationshipElement, AnnotatedRelationshipElement, Range, Blob, File, \
     ReferenceElement, DataElement, AdministrativeInformation, AbstractObjectStore, \
     Namespace, SubmodelElementCollection, SubmodelElement, ModelReference, Referable, Identifiable, \
-    Key, Qualifier, BasicEventElement, SubmodelElementList, datatypes, LangStringSet, SetObjectStore
+    Key, Qualifier, BasicEventElement, SubmodelElementList, datatypes, LangStringSet, \
+    AbstractObjectProvider
 
 import aas_editor.additional.classes
 import aas_editor.package
@@ -132,7 +134,10 @@ CLASSES_INFO = {
         },
         IS_EDITABLE_IN_GUI: False,
     },
-    SetObjectStore: {
+    AbstractObjectProvider: {
+        IS_EDITABLE_IN_GUI: False,
+    },
+    AbstractSupplementaryFileContainer: {
         IS_EDITABLE_IN_GUI: False,
     },
     Referable: {

--- a/aas_editor/settings/icons.py
+++ b/aas_editor/settings/icons.py
@@ -7,8 +7,6 @@
 #  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 #  A copy of the GNU General Public License is available at http://www.gnu.org/licenses/
-from directories import get_icons_folder
-
 from PyQt6.QtGui import QColor, QIcon, QPainter, QPixmap, QFont
 from PyQt6.QtSvg import QSvgRenderer
 
@@ -195,6 +193,6 @@ ICONS_SVG = {
 }
 
 def initialize_all_icons():
-    from settings.app_settings import ICONS_FOLDER
+    from aas_editor.settings.app_settings import ICONS_FOLDER
     for icon, svg_file in ICONS_SVG.items():
         transform_svg_to_icon(icon, str(ICONS_FOLDER / svg_file))

--- a/aas_editor/widgets/aas_test_engines_tool.py
+++ b/aas_editor/widgets/aas_test_engines_tool.py
@@ -54,7 +54,7 @@ class AasTestEnginesToolDialog(QDialog):
         self.setMinimumSize(500, 300)
 
         description = 'Official test tooling for the Asset Administration Shell: https://github.com/admin-shell-io/aas-test-engines'
-        self.html_renderer = DropFileQWebEngineView(self, emptyViewMsg="Drop AAS file to test it", description=description)
+        self.html_renderer = DropFileQWebEngineView(self, emptyViewMsg="Drop AAS file to test here", description=description)
         self.html_renderer.setMinimumSize(300, 300)
         self.html_renderer.fileDropped.connect(self.checkFile)
 

--- a/aas_editor/widgets/treeview.py
+++ b/aas_editor/widgets/treeview.py
@@ -558,7 +558,7 @@ class TreeView(BasicTreeView):
             self._setItemData(index, NOT_GIVEN, CLEAR_ROW_ROLE)
 
     def onMultipleDelClear(self, indexes: List[QModelIndex]):
-        for index in indexes:
+        for index in sorted(indexes, key=lambda x: x.row(), reverse=True):  # reverse to avoid shifting rows
             self.onOneItemDelClear(index)
 
     def onCopy(self):

--- a/aas_editor/widgets/treeview_pack.py
+++ b/aas_editor/widgets/treeview_pack.py
@@ -28,7 +28,8 @@ from basyx.aas.model import SetObjectStore, Submodel
 
 from aas_editor.delegates import EditDelegate
 from aas_editor.package import Package, StoredFile
-from aas_editor.settings import FILTER_AAS_FILES, AAS_FILE_TYPE_FILTERS, NOT_GIVEN, REFERABLE_INHERITORS_ATTRS
+from aas_editor.settings import FILTER_AAS_FILES, AAS_FILE_TYPE_FILTERS, NOT_GIVEN, REFERABLE_INHERITORS_ATTRS, \
+    AAS_FILE_TYPES, APPLICATION_NAME, IAT
 from aas_editor.settings.app_settings import NAME_ROLE, OBJECT_ROLE, PACKAGE_ROLE, \
     MAX_RECENT_FILES, OPENED_PACKS_ROLE, OPENED_FILES_ROLE, ADD_ITEM_ROLE, \
     CLEAR_ROW_ROLE, AppSettings, COLUMN_NAME_ROLE, OBJECT_COLUMN_NAME, \
@@ -41,7 +42,6 @@ from aas_editor.utils.util_classes import ClassesInfo
 from aas_editor.widgets import TreeView
 from aas_editor.widgets.treeview import HeaderView
 from aas_editor import dialogs
-from settings import AAS_FILE_TYPES, APPLICATION_NAME, IAT
 
 
 SUBMODEL_TEMPLATES_FOLDER = 'submodel_templates'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,10 @@ version = "0.4.7"
 dependencies = [
     "PyQt6",
     "basyx-python-sdk@git+https://github.com/rwth-iat/basyx-python-sdk@aas_manager/v301#subdirectory=sdk",
-    "aas_test_engines",
+    "aas-test-engines==1.0.3",
     "pytz>=2023.3",
     "PyQt6-WebEngine",
-    "pyinstaller==6.4.0",
+    "pyinstaller==6.15.0",
     "openpyxl>=3.1.2",
     "toml>=0.10.2",
 ]


### PR DESCRIPTION
- Added "copy IdShortPath" feature for `Referable` objects
- Upgraded dependencies and python version
- Fixed the delete multiple items feature
- Used propper json & xml adapter funcs
- Forbid to edit obj- & filestore in dialog
- Fixed README.md
- Added submodel-templates to use the "Add existing submodel" feature