### PR TITLE
Fix exception handling in StandardItem class to include ValueError

### DIFF
--- a/aas_editor/models/item_standard.py
+++ b/aas_editor/models/item_standard.py
@@ -253,7 +253,7 @@ class StandardItem(QObject):
             try:
                 data.resolve(self.package.objStore)
                 return True
-            except (AttributeError, KeyError, NotImplementedError, TypeError, IndexError) as e:
+            except (AttributeError, KeyError, NotImplementedError, TypeError, IndexError, ValueError) as e:
                 logging.exception(e)
                 return False
         return False


### PR DESCRIPTION
When expanding all items (Ctrl + Shift + +), QT renders all visible items and calls `isLink()` on each one to determine link styling.
`ModelReference.resolve()` can raise a `ValueError` when a non-numeric key is used.

Now `ValueError`s are caught to prevent a crash of the QT rendering pipeline.

Fixes #72 